### PR TITLE
Optional Chaining & Multiplier Utility

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
    "presets": ["@babel/preset-env", "@babel/react"],
    "plugins": [
+      "@babel/plugin-proposal-optional-chaining",
       ["@babel/plugin-proposal-decorators", {
          "legacy": true,
       }],

--- a/package-lock.json
+++ b/package-lock.json
@@ -345,6 +345,16 @@
         "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
       }
     },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.2.0.tgz",
+      "integrity": "sha512-ea3Q6edZC/55wEBVZAEz42v528VulyO0eir+7uky/sT4XRcdkWJcFi1aPtitTlwUzGnECWJNExWww1SStt+yWw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.2.0"
+      }
+    },
     "@babel/plugin-proposal-unicode-property-regex": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.2.0.tgz",
@@ -414,6 +424,15 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.2.0.tgz",
+      "integrity": "sha512-HtGCtvp5Uq/jH/WNUPkK6b7rufnCPLLlDAFN7cmACoIjaOOiXxUt3SswU5loHqrhtqTsa/WoLQ1OQ1AGuZqaWA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@babel/core": "7.1.2",
     "@babel/plugin-proposal-class-properties": "7.1.0",
     "@babel/plugin-proposal-decorators": "7.1.2",
+    "@babel/plugin-proposal-optional-chaining": "^7.2.0",
     "@babel/preset-env": "7.1.0",
     "@babel/preset-react": "7.0.0",
     "@babel/runtime": "7.1.5",

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -81,11 +81,11 @@ const pulsingAnimation = keyframes`
    } = props
 
    // Responsive Props
-   const borderRadius = props.borderRadius && props.borderRadius[breakpoint]
-   const color = props.color && props.color[breakpoint]
-   const fontFamily = props.fontFamily && props.fontFamily[breakpoint]
-   const padding = props.padding && props.padding[breakpoint]
-   const size = props.size && props.size[breakpoint]
+   const borderRadius = props.borderRadius?.[breakpoint]
+   const color = props.color?.[breakpoint]
+   const fontFamily = props.fontFamily?.[breakpoint]
+   const padding = props.padding?.[breakpoint]
+   const size = props.size?.[breakpoint]
 
    // If user passes invalid button 'size'
    const sizeOptions = Object.keys(buttonSizeDefaults)
@@ -96,10 +96,10 @@ const pulsingAnimation = keyframes`
    const height = buttonSizeDefaults[size].height
    const width = props.width[breakpoint]
 
-   const textColor = props.textColor && props.textColor[breakpoint]
-   const textSize = props.textSize && props.textSize[breakpoint]
-   const textTransform = props.textTransform && props.textTransform[breakpoint]
-   const textWeight = props.textWeight && props.textWeight[breakpoint]
+   const textColor = props.textColor?.[breakpoint]
+   const textSize = props.textSize?.[breakpoint]
+   const textTransform = props.textTransform?.[breakpoint]
+   const textWeight = props.textWeight?.[breakpoint]
 
    const primaryButtonColor = color || OIOContext.highlightColor
    const defaultButtonPadding = width === 'auto' ? `0px ${height}` : '0px'

--- a/src/utils/applyMultiplier.js
+++ b/src/utils/applyMultiplier.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line max-len
 const cssNumValRegex = /(\D*)(-?[0-9]+(?:\.[0-9]+)?)(cm|mm|in|px|pt|pc|em|ex|ch|rem|vw|vh|vmin|vmax|%|deg|rad)?(\D*)/gi
 const unitsToIgnore = ['%', 'deg', 'rad']
 

--- a/src/utils/applyMultiplier.js
+++ b/src/utils/applyMultiplier.js
@@ -2,13 +2,13 @@
 const cssNumValRegex = /(\D*)(-?[0-9]+(?:\.[0-9]+)?)(cm|mm|in|px|pt|pc|em|ex|ch|rem|vw|vh|vmin|vmax|%|deg|rad)?(\D*)/gi
 const unitsToIgnore = ['%', 'deg', 'rad']
 
-export default (value, scaleMultiplier, round = false) => {
-   if (typeof scaleMultiplier !== 'number') {
+export default (value, multiplier, round = false) => {
+   if (typeof multiplier !== 'number') {
       throw new Error('Scale multiplier must be a number')
    }
 
-   if (scaleMultiplier === 1) return value
-   if (typeof value === 'number') return value * scaleMultiplier
+   if (multiplier === 1) return value
+   if (typeof value === 'number') return value * multiplier
    if (typeof value !== 'string') return value
 
    return value.replace(cssNumValRegex, (match, prefix, amount, unit = '', suffix) => {
@@ -19,7 +19,7 @@ export default (value, scaleMultiplier, round = false) => {
       // that's not supported in babel or by most browsers (yet), though it
       // is a stage 4 tc39 proposal.
       const isNegative = prefix.endsWith('-')
-      let number = parseFloat(amount) * scaleMultiplier
+      let number = parseFloat(amount) * multiplier
       if (isNegative) number *= -1
       if (round) number = Math.round(number)
 

--- a/src/utils/applyMultiplier.js
+++ b/src/utils/applyMultiplier.js
@@ -1,0 +1,27 @@
+const cssNumValRegex = /(\D*)(-?[0-9]+(?:\.[0-9]+)?)(cm|mm|in|px|pt|pc|em|ex|ch|rem|vw|vh|vmin|vmax|%|deg|rad)?(\D*)/gi
+const unitsToIgnore = ['%', 'deg', 'rad']
+
+export default (value, scaleMultiplier, round = false) => {
+   if (typeof scaleMultiplier !== 'number') {
+      throw new Error('Scale multiplier must be a number')
+   }
+
+   if (scaleMultiplier === 1) return value
+   if (typeof value === 'number') return value * scaleMultiplier
+   if (typeof value !== 'string') return value
+
+   return value.replace(cssNumValRegex, (match, prefix, amount, unit = '', suffix) => {
+      if (unitsToIgnore.includes(unit)) return match
+
+      // Kinda hacky way to check if it was a negative number.
+      // Ideally, we would use a regex negative lookbehind assertion, but
+      // that's not supported in babel or by most browsers (yet), though it
+      // is a stage 4 tc39 proposal.
+      const isNegative = prefix.endsWith('-')
+      let number = parseFloat(amount) * scaleMultiplier
+      if (isNegative) number *= -1
+      if (round) number = Math.round(number)
+
+      return `${isNegative ? prefix.slice(0, -1) : prefix}${number}${unit}${suffix}`
+   })
+}

--- a/tests/utils/applyMultiplier/index.js
+++ b/tests/utils/applyMultiplier/index.js
@@ -1,0 +1,81 @@
+import applyMultiplier from '../../../src/utils/applyMultiplier'
+
+test('It will throw an error if valid scale multiplier is not passed in', () => {
+   expect(() => applyMultiplier(10)).toThrowError('multiplier must be a number')
+   expect(() => applyMultiplier(10, false)).toThrowError('multiplier must be a number')
+   expect(() => applyMultiplier(10, '1.5')).toThrowError('multiplier must be a number')
+})
+
+test('It will scale a number correctly', () => {
+   expect(applyMultiplier(100, 1.5)).toBe(150)
+   expect(applyMultiplier(100, -1.5)).toBe(-150)
+   expect(applyMultiplier(-100, 1.5)).toBe(-150)
+   expect(applyMultiplier(-100, -1.5)).toBe(150)
+   expect(applyMultiplier(25, 0.5)).toBe(12.5)
+})
+
+test('It will not apply to booleans, null, undefined, empty strings', () => {
+   expect(applyMultiplier(true, -1)).toBe(true)
+   expect(applyMultiplier(null, -1.5)).toBe(null)
+   expect(applyMultiplier(undefined, 5)).toBe(undefined)
+   expect(applyMultiplier('', -1)).toBe('')
+})
+
+test('It will throw an error if valid scale multiplier is not passed in', () => {
+   expect(() => applyMultiplier(10)).toThrowError('multiplier must be a number')
+   expect(() => applyMultiplier(10, false)).toThrowError('multiplier must be a number')
+   expect(() => applyMultiplier(10, '1.5')).toThrowError('multiplier must be a number')
+})
+
+test('It correctly scales a simple numeric string measured absolutely', () => {
+   expect(applyMultiplier('10px', 0.5)).toBe('5px')
+   expect(applyMultiplier('10', 0.5)).toBe('5')
+   expect(applyMultiplier('2.5', 0.5)).toBe('1.25')
+   expect(applyMultiplier('10.5px', 0.5)).toBe('5.25px')
+   expect(applyMultiplier('10vmax', 0.5)).toBe('5vmax')
+   expect(applyMultiplier('100px', -1.5)).toBe('-150px')
+   expect(applyMultiplier('-100', 1.5)).toBe('-150')
+   expect(applyMultiplier('-100em', -1.5)).toBe('150em')
+   expect(applyMultiplier('-25px', 0.5)).toBe('-12.5px')
+})
+
+test('It correctly skips numeric strings measured proportionally', () => {
+   expect(applyMultiplier('10%', 0.5)).toBe('10%')
+   expect(applyMultiplier('10.5%', 0.5)).toBe('10.5%')
+   expect(applyMultiplier('-10.5%', 0.5)).toBe('-10.5%')
+   expect(applyMultiplier('5deg', 0.5)).toBe('5deg')
+   expect(applyMultiplier('5rad', 0.5)).toBe('5rad')
+})
+
+test('It optionally rounds resulting values', () => {
+   expect(applyMultiplier('2.9px solid red', 0.5, true)).toBe('1px solid red')
+   expect(applyMultiplier('-5px solid red', 0.5, true)).toBe('-2px solid red')
+})
+
+test('It correctly scales CSS border-like values', () => {
+   expect(applyMultiplier('10px solid red', 0.5)).toBe('5px solid red')
+   expect(applyMultiplier('10 solid red', 0.5)).toBe('5 solid red')
+   expect(applyMultiplier('10% solid #fff', 0.5)).toBe('10% solid #fff')
+})
+
+test('It correctly scales CSS padding-like values', () => {
+   expect(applyMultiplier('10px 10px', 0.5)).toBe('5px 5px')
+   expect(applyMultiplier('10px -10px', 0.5)).toBe('5px -5px')
+   expect(applyMultiplier('10pt -10 10% 5em', 0.5)).toBe('5pt -5 10% 2.5em')
+   expect(applyMultiplier('10px !important', 0.5)).toBe('5px !important')
+   expect(applyMultiplier('10 auto', 0.5)).toBe('5 auto')
+})
+
+test('It correctly scales CSS calc-like values', () => {
+   expect(applyMultiplier('calc(100% - 10px)', 0.5)).toBe('calc(100% - 5px)')
+   expect(applyMultiplier('calc(100px + 10%)', 0.5)).toBe('calc(50px + 10%)')
+   expect(applyMultiplier('calc(100px + 100)', 0.5)).toBe('calc(50px + 50)')
+   expect(applyMultiplier('calc(100px + 100px)', 0.5)).toBe('calc(50px + 50px)')
+})
+
+test('It correctly scales CSS transform-like values', () => {
+   expect(applyMultiplier('skewX(25deg)', 0.5)).toBe('skewX(25deg)')
+   expect(applyMultiplier('translate(20px, 10px)', 0.5)).toBe('translate(10px, 5px)')
+   expect(applyMultiplier('scale(20) skew(-20deg)', 0.5)).toBe('scale(10) skew(-20deg)')
+   expect(applyMultiplier('scale(20) translate(20px,10px)', 0.5)).toBe('scale(10) translate(10px,5px)')
+})


### PR DESCRIPTION
**Description**

This PR introduces [optional chaining](https://github.com/tc39/proposal-optional-chaining), which is now a stage 2 tc39 proposal. Also adds a small utility function that will take a CSS-like value, and apply a scale multiplier to amounts contained in that string (except if those numbers are proportional numbers, like percentages or degrees).

Addresses #35 

**Known Issues**
- Linter does not like the optional chaining, will need to update in eslint-config-mother
- No negative lookbehind assertions kinda makes negative number transformation a bit dumb. More info here: https://github.com/tc39/proposal-regexp-lookbehind
- Probably missed some weird edge cases or CSS units or classification of proportional units