### PR TITLE
View Events Specimen (merge #38 first)

### DIFF
--- a/docs/pages/API/View/index.js
+++ b/docs/pages/API/View/index.js
@@ -3,6 +3,7 @@ import APITableBlock from '../../../components/APITableBlock'
 import HeaderBlock from '../../../components/HeaderBlock'
 import SpecimenBlock from '../../../components/SpecimenBlock'
 import ViewBasicSpecimen from '../../../specimens/ViewBasic'
+import ViewEventsSpecimen from '../../../specimens/ViewEvents'
 import viewSpec from '../../../../src/View/spec'
 import viewSpecAppearance from '../../../../src/View/specAppearance'
 import viewSpecFlexbox from '../../../../src/View/specFlexbox'
@@ -12,20 +13,7 @@ const ViewPage = () => (
    <div>
       <HeaderBlock title="View" />
       <SpecimenBlock specimen={ViewBasicSpecimen} />
-      <SpecimenBlock
-         title="Supported Events"
-         codeSnippet={'<View onClick={doSomething}>Synthetic Events</View>'}
-         description={`
-            The <code>View</code> component supports the following React  events:<br /><br />
-            <code>
-               onClick, onCopy, onCut, onPaste, onDoubleClick, onKeyDown, onKeyPress, onKeyUp,
-               onMouseDown, onMouseMove, onMouseOut, onMouseOver, onMouseUp, onScroll,
-               onTouchCancel, onTouchEnd, onTouchMove, onTouchStart, onTransitionEnd
-            </code>
-            <br /><br />
-            (Visit <a href="https://reactjs.org/docs/events.html">https://reactjs.org/docs/events.html</a> for more information about React SyntheticEvents)
-         `}
-      />
+      <SpecimenBlock specimen={ViewEventsSpecimen} />
       <APITableBlock spec={viewSpec} title="Basic Formatting API Options" />
       <APITableBlock spec={viewSpecAppearance} title="Appearance API Options" />
       <APITableBlock spec={viewSpecFlexbox} title="FlexBox API Options" />

--- a/docs/specimens/ViewEvents/index.js
+++ b/docs/specimens/ViewEvents/index.js
@@ -1,0 +1,92 @@
+import React, { useRef, useState } from 'react'
+import { View } from '../../../src'
+
+const supportedEvents = [
+   'onClick', 'onDoubleClick', 'onKeyDown', 'onKeyPress', 'onKeyUp',
+   'onMouseDown', 'onMouseMove', 'onMouseOut', 'onMouseOver', 'onMouseUp', 'onScroll',
+   'onTouchCancel', 'onTouchEnd', 'onTouchMove', 'onTouchStart', 'onTransitionEnd'
+]
+
+const ViewEventsSpecimen = () => {
+   const viewRef = useRef(null)
+   const [eventType, setEventType] = useState(null)
+   const [mousePosition, setMousePosition] = useState(null)
+
+   const handleEvent = (e) => {
+      viewRef.current.focus()
+      if (e.type === 'mouseout') setMousePosition(null)
+      if (e.type !== 'mousemove') setEventType(e.type)
+      else setMousePosition([e.clientX, e.clientY])
+   }
+
+   const eventProps = supportedEvents.reduce((result, eventName) => {
+      result[eventName] = handleEvent
+      return result
+   }, {})
+
+   return (
+      <View
+         ref={viewRef}
+         backgroundColor="#fff4eb"
+         border="1px solid #f46f36"
+         borderRadius="6px"
+         padding="30px"
+         tabIndex="0"
+         {...eventProps}>
+         {eventType && `Last Event Type: ${eventType}`}<br />
+         {mousePosition && `Mouse Position: ${mousePosition[0]}, ${mousePosition[1]}`}
+      </View>
+   )
+}
+
+ViewEventsSpecimen.title = 'Supported Events'
+
+ViewEventsSpecimen.description = `
+The <code>View</code> component supports the following React  events:<br /><br />
+<code>
+   onClick, onDoubleClick, onKeyDown, onKeyPress, onKeyUp,
+   onMouseDown, onMouseMove, onMouseOut, onMouseOver, onMouseUp, onScroll,
+   onTouchCancel, onTouchEnd, onTouchMove, onTouchStart, onTransitionEnd
+</code>
+<br /><br />
+(Visit <a href="https://reactjs.org/docs/events.html">https://reactjs.org/docs/events.html</a> for more information about React SyntheticEvents)
+`
+
+ViewEventsSpecimen.codeSnippet = `
+const supportedEvents = [
+   'onClick', 'onDoubleClick', 'onKeyDown', 'onKeyPress', 'onKeyUp',
+   'onMouseDown', 'onMouseMove', 'onMouseOut', 'onMouseOver', 'onMouseUp', 'onScroll',
+   'onTouchCancel', 'onTouchEnd', 'onTouchMove', 'onTouchStart', 'onTransitionEnd'
+]
+
+const viewRef = useRef(null)
+const [eventType, setEventType] = useState(null)
+const [mousePosition, setMousePosition] = useState(null)
+
+const handleEvent = (e) => {
+   viewRef.current.focus()
+   if (e.type === 'mouseout') setMousePosition(null)
+   if (e.type !== 'mousemove') setEventType(e.type)
+   else setMousePosition([e.clientX, e.clientY])
+}
+
+const eventProps = supportedEvents.reduce((result, eventName) => {
+   result[eventName] = handleEvent
+   return result
+}, {})
+
+return (
+   <View
+      ref={viewRef}
+      backgroundColor="#fff4eb"
+      border="1px solid #f46f36"
+      borderRadius="6px"
+      padding="30px"
+      tabIndex="0"
+      {...eventProps}>
+      {eventType && \`Last Event Type: \${eventType}\`}<br />
+      {mousePosition && \`Mouse Position: \${mousePosition[0]}, \${mousePosition[1]}\`}
+   </View>
+)`
+
+export default ViewEventsSpecimen

--- a/src/View/index.js
+++ b/src/View/index.js
@@ -151,6 +151,7 @@ export default class View extends React.Component {
       position: OIOResponsiveObjectPropType,
       scroll: OIOResponsiveObjectPropType,
       style: PropTypes.object,
+      tabIndex: PropTypes.string,
       textAlign: OIOResponsiveObjectPropType,
       top: OIOResponsiveObjectPropType,
       transform: OIOResponsiveObjectPropType,
@@ -187,7 +188,8 @@ export default class View extends React.Component {
       onTouchStart: undefined,
       onTransitionEnd: undefined,
       position: r`relative`,
-      style: {}
+      style: {},
+      tabIndex: undefined
    }
 
    render() {
@@ -202,9 +204,10 @@ export default class View extends React.Component {
          backgroundColor, backgroundImage, backgroundPosition, backgroundSize,
          borderRadius, boxShadow, opacity, textAlign, transform, transition, zIndex,
          overflow, WebkitOverflowScrolling,
-         onClick, onCopy, onCut, onPaste, onDoubleClick, onKeyDown, onKeyPress, onKeyUp,
+         onClick, onDoubleClick, onKeyDown, onKeyPress, onKeyUp,
          onMouseDown, onMouseMove, onMouseOut, onMouseOver, onMouseUp, onScroll,
-         onTouchCancel, onTouchEnd, onTouchMove, onTouchStart, onTransitionEnd
+         onTouchCancel, onTouchEnd, onTouchMove, onTouchStart, onTransitionEnd,
+         tabIndex
       } = this.props
 
       // Generate CSS responsive styles with Emotion
@@ -222,7 +225,7 @@ export default class View extends React.Component {
       })
 
       const eventHandlers = {
-         onClick, onCopy, onCut, onPaste, onDoubleClick, onKeyDown, onKeyPress, onKeyUp,
+         onClick, onDoubleClick, onKeyDown, onKeyPress, onKeyUp,
          onMouseDown, onMouseMove, onMouseOut, onMouseOver, onMouseUp, onScroll,
          onTouchCancel, onTouchEnd, onTouchMove, onTouchStart, onTransitionEnd
       }
@@ -238,7 +241,8 @@ export default class View extends React.Component {
                ...this.props.style,
                ...responsiveStyles
             }}
-            className={className}>
+            className={className}
+            tabIndex={tabIndex}>
             {children}
          </div>
       )

--- a/src/View/spec.js
+++ b/src/View/spec.js
@@ -89,6 +89,12 @@ export default [{
    description: 'css equivalent value',
    responsive: true
 }, {
+   name: 'scroll',
+   type: 'String',
+   default: '-',
+   description: '<code>on</code> to make it scrollable, omit otherwise',
+   responsive: true
+}, {
    name: 'style',
    type: 'Object',
    default: '<code>{}</code>',

--- a/tests/visual/View.js
+++ b/tests/visual/View.js
@@ -1,7 +1,22 @@
-context('View', () => {
+context.only('View', () => {
    it('Renders kitchen sink test as expected', () => {
       cy.viewport(1360, 860)
       cy.visit('/tests/view-kitchen-sink')
       cy.testImageSnapshot('View - Kitchen Sink')
+   })
+
+   it('View events are supported', () => {
+      cy.viewport(1360, 860)
+      cy.visit('/tests/view-events')
+
+      const $div = cy.get('div:first')
+      $div.click()
+      $div.should('contain', 'click')
+      $div.click()
+      $div.should('contain', 'click')
+      $div.trigger('mouseover')
+      $div.should('contain', 'mouseover')
+      $div.trigger('touchstart')
+      $div.should('contain', 'touchstart')
    })
 })


### PR DESCRIPTION
**Requires**
- Merge #38 first

**Tasks**
- [x] Create Specimen that demonstrates `View` events
- [x] Removed support for cut, copy, paste events since they only work with div that have the `contenteditable` prop, which is not supported by `View` at this time
- [x] Add basic test for view events
- [x] Add support for `tabIndex` prop
- [x] Document `scroll` prop