### PR TITLE
Critical Link Adapter Fixes

### DIFF
--- a/docs/specimens/ListMenuLinks/index.js
+++ b/docs/specimens/ListMenuLinks/index.js
@@ -15,7 +15,7 @@ const ListMenuLinksSpecimen = ({ match }) => (
          buttonBorderRadius="3px"
          dividerLineStyle="none"
          showActiveArrow>
-         <ListMenuButton name="Home" linkTo={`${match.url}`} />
+         <ListMenuButton name="Home" linkTo={`${match.url}`} linkExact />
          <ListMenuButton name="Explore" linkTo={`${match.url}/explore`} />
          <ListMenuButton name="Notifications" linkTo={`${match.url}/notifications`} />
          <ListMenuButton name="Profile" linkTo={`${match.url}/profile`} />
@@ -40,7 +40,7 @@ ListMenuLinksSpecimen.codeSnippet = `
       buttonBorderRadius="3px"
       dividerLineStyle="none"
       showActiveArrow>
-      <ListMenuButton name="Home" linkTo={\`\${match.url}\`} />
+      <ListMenuButton name="Home" linkTo={\`\${match.url}\`} linkExact />
       <ListMenuButton name="Explore" linkTo={\`\${match.url}/explore\`} />
       <ListMenuButton name="Notifications" linkTo={\`\${match.url}/notifications\`} />
       <ListMenuButton name="Profile" linkTo={\`\${match.url}/profile\`} />

--- a/docs/specimens/OIOProviderReactRouter/index.js
+++ b/docs/specimens/OIOProviderReactRouter/index.js
@@ -6,13 +6,13 @@ OIOProviderReactRouterSpecimen.description = 'Some of the button components that
 
 OIOProviderReactRouterSpecimen.codeSnippet = `
 const buttonLinkAdapter = {
-   render: ({ linkTo, linkReplace, ...props }) => (
+   render: ({ linkTo, linkReplace, linkExact, ...props }) => (
       <Link to={linkTo} replace={linkReplace} {...props} />
    )
 
    // isActive can be overridden if custom logic is needed to
    // specify whether the current link is active
-   // isActive: link => matchPath(link)
+   // isActive: (linkTo, linkExact) => matchPath(linkTo, linkExact)
 }
 
 const myComponent = () => (

--- a/docs/specimens/TabMenuLinks/index.js
+++ b/docs/specimens/TabMenuLinks/index.js
@@ -9,7 +9,7 @@ const TabMenuLinksSpecimen = ({ match }) => (
       border="1px solid #eee"
       borderRadius="3px">
       <TabMenu>
-         <TabMenuButton name="Tab Button 1" linkTo={match.url} />
+         <TabMenuButton name="Tab Button 1" linkTo={match.url} linkExact />
          <TabMenuButton name="Tab Button 2" linkTo={`${match.url}/2`} />
          <TabMenuButton name="Tab Button 3" linkTo={`${match.url}/3`} />
       </TabMenu>
@@ -27,7 +27,7 @@ TabMenuLinksSpecimen.codeSnippet = `
    border="1px solid #eee"
    borderRadius="3px">
    <TabMenu>
-      <TabMenuButton name="Tab Button 1" linkTo={match.url} />
+      <TabMenuButton name="Tab Button 1" linkTo={match.url} linkExact />
       <TabMenuButton name="Tab Button 2" linkTo={\`\${match.url}/2\`} />
       <TabMenuButton name="Tab Button 3" linkTo={\`\${match.url}/3\`} />
    </TabMenu>

--- a/src/ListMenu/index.js
+++ b/src/ListMenu/index.js
@@ -28,7 +28,7 @@ const ListMenu = ({
          // Determine if child should have active link (if applicable)
          let childIsActive = child.props.isActive
          if (!linkHasAlreadyMatched && child.props.linkTo && typeof childIsActive === 'undefined') {
-            childIsActive = buttonLinkAdapter.isActive(child.props.linkTo)
+            childIsActive = buttonLinkAdapter.isActive(child.props.linkTo, child.props.linkExact)
             if (childIsActive) {
                linkHasAlreadyMatched = true
             }

--- a/src/ListMenuButton/index.js
+++ b/src/ListMenuButton/index.js
@@ -15,6 +15,7 @@ const ListMenuButton = ({
    borderRadius,
    isActive,
    linkTo,
+   linkExact,
    linkReplace,
    name,
    onClick,
@@ -85,7 +86,12 @@ const ListMenuButton = ({
    )
 
    if (linkTo && buttonLinkAdapter) {
-      return buttonLinkAdapter.render({ linkTo, linkReplace, children: listMenuButtonJSX })
+      return buttonLinkAdapter.render({
+         linkTo,
+         linkExact,
+         linkReplace,
+         children: listMenuButtonJSX
+      })
    }
 
    return listMenuButtonJSX
@@ -98,6 +104,7 @@ ListMenuButton.propTypes = {
    borderRadius: PropTypes.string,
    isActive: PropTypes.bool,
    linkTo: PropTypes.any,
+   linkExact: PropTypes.bool,
    linkReplace: PropTypes.bool,
    name: PropTypes.string.isRequired,
    onClick: PropTypes.func,
@@ -117,6 +124,7 @@ ListMenuButton.defaultProps = {
    borderRadius: '0px',
    isActive: undefined,
    linkTo: undefined,
+   linkExact: false,
    linkReplace: false,
    onClick: undefined,
    paddingHorizontal: '18px',

--- a/src/ListMenuButton/spec.js
+++ b/src/ListMenuButton/spec.js
@@ -11,6 +11,12 @@ export default [{
    description: 'Passed to <code>OIOProvider</code> button link adapater. See OIOProvider docs for details.',
    responsive: false
 }, {
+   name: 'linkExact',
+   type: 'Boolean',
+   default: '<code>false</code>',
+   description: 'Passed to <code>OIOProvider</code> button link adapater. See OIOProvider docs for details.',
+   responsive: false
+}, {
    name: 'linkReplace',
    type: 'Boolean',
    default: '<code>false</code>',

--- a/src/OIOProvider/buttonLinkAdapterSpec.js
+++ b/src/OIOProvider/buttonLinkAdapterSpec.js
@@ -2,7 +2,7 @@ export default [{
    name: 'isActive',
    type: 'Function',
    default: 'See Description',
-   description: 'A function that is passed in a link. This function must return a boolean that represents whether the link is currently active. The default function does a simple check based on <code>window.location.pathname</code>. This is only used by <code>ListMenuButton</code>, and not <code>Button</code>.'
+   description: 'A function that is passed in a link. This function must return a boolean that represents whether the link is currently active. The default function does a simple check based on <code>window.location.pathname</code>. This is only by <code>ListMenuButton</code> and <code>TabMenuButton</code>, but not <code>Button</code>.'
 }, {
    name: 'render',
    type: 'Function',

--- a/src/OIOProvider/index.js
+++ b/src/OIOProvider/index.js
@@ -45,7 +45,9 @@ const OIOProvider = ({
       textSizeScaleRatio,
       containerId: containerId.current,
       buttonLinkAdapter: {
-         isActive: linkTo => linkTo.startsWith(window.location.pathname),
+         isActive: (linkTo, linkExact = false) => linkExact
+            ? window.location.pathname === linkTo
+            : window.location.pathname.startsWith(linkTo),
          render: ({ linkTo, children }) => <a href={linkTo}>{children}</a>,
          ...buttonLinkAdapter
       }

--- a/src/TabMenu/index.js
+++ b/src/TabMenu/index.js
@@ -108,7 +108,7 @@ const TabMenu = ({
       if (child) {
          let childIsActive = child.props.isActive
          if (!linkHasAlreadyMatched && child.props.linkTo && typeof childIsActive === 'undefined') {
-            childIsActive = buttonLinkAdapter.isActive(child.props.linkTo)
+            childIsActive = buttonLinkAdapter.isActive(child.props.linkTo, child.props.linkExact)
             if (childIsActive) {
                linkHasAlreadyMatched = true
             }

--- a/src/TabMenuButton/index.js
+++ b/src/TabMenuButton/index.js
@@ -16,6 +16,7 @@ const TabMenuButton = ({
    highlightColor,
    isActive,
    linkTo,
+   linkExact,
    linkReplace,
    name,
    onClick,
@@ -65,7 +66,12 @@ const TabMenuButton = ({
    )
 
    if (linkTo && buttonLinkAdapter) {
-      return buttonLinkAdapter.render({ linkTo, linkReplace, children: tabButtonJSX })
+      return buttonLinkAdapter.render({
+         linkTo,
+         linkExact,
+         linkReplace,
+         children: tabButtonJSX
+      })
    }
 
    return tabButtonJSX
@@ -75,6 +81,9 @@ TabMenuButton.propTypes = {
    badgeNumber: PropTypes.number,
    highlightColor: PropTypes.string,
    isActive: PropTypes.bool,
+   linkTo: PropTypes.any,
+   linkExact: PropTypes.bool,
+   linkReplace: PropTypes.bool,
    name: PropTypes.string.isRequired,
    onClick: PropTypes.func,
    paddingHorizontal: PropTypes.string,
@@ -85,6 +94,9 @@ TabMenuButton.defaultProps = {
    badgeNumber: undefined,
    highlightColor: '#000',
    isActive: false,
+   linkTo: undefined,
+   linkExact: false,
+   linkReplace: false,
    onClick: undefined,
    paddingHorizontal: undefined,
    size: undefined

--- a/src/TabMenuButton/spec.js
+++ b/src/TabMenuButton/spec.js
@@ -17,6 +17,12 @@ export default [{
    description: 'Passed to <code>OIOProvider</code> button link adapater. See OIOProvider docs for details.',
    responsive: false
 }, {
+   name: 'linkExact',
+   type: 'Boolean',
+   default: '<code>false</code>',
+   description: 'Passed to <code>OIOProvider</code> button link adapater. See OIOProvider docs for details.',
+   responsive: false
+}, {
    name: 'linkReplace',
    type: 'Boolean',
    default: '<code>false</code>',


### PR DESCRIPTION
Fixes an issue where the default `isActive` fn checked if `linkTo.startsWith(window.location.pathname)` instead of the correct way of `window.location.pathname.startsWith(linkTo)`.

`linkExact` is added as a prop to `ListMenuButton` and `TabMenuButton` as well